### PR TITLE
BUG FIX users can now complete orders

### DIFF
--- a/components/order/form-modal.js
+++ b/components/order/form-modal.js
@@ -1,20 +1,20 @@
 import { useState } from "react"
 import Modal from "../modal"
 
-export default function CompleteFormModal({ showModal, setShowModal, paymentTypes, completeOrder }) {
+export default function CompleteFormModal({ showModal, setShowModal, paymentTypes, completeOrder, cart }) {
   const [selectedPayment, setSelectedPayment] = useState(0)
   return (
     <Modal showModal={showModal} setShowModal={setShowModal} title="Complete Order">
       <div className="select">
-        <select value={selectedPayment} onChange={(event) => setSelectedPayment(event.target.value)}>
+        <select value={selectedPayment} onChange={(event) => setSelectedPayment(parseInt(event.target.value))}>
           <option>Select a payment type to complete your order</option>
           {
-            paymentTypes.map(pt => <option key={pt.id} value={pt.id}>{pt.merchant_name} {pt.obscured_num}</option>)
+            paymentTypes.map(pt => <option key={pt.id} value={pt.id}>{pt.merchant_name} {pt.account_number}</option>)
           }
         </select>
       </div>
       <>
-        <button className="button is-success" onClick={() => completeOrder(selectedPayment)}>Complete Order</button>
+      <button className="button is-success" onClick={() => completeOrder(cart.id, selectedPayment)}>Complete Order</button>
         <button className="button" onClick={() => setShowModal(false)}>Cancel</button>
       </>
     </Modal>

--- a/data/auth.js
+++ b/data/auth.js
@@ -21,7 +21,7 @@ export function register(user) {
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('my-profile', {
+  return fetchWithResponse('profile', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
     }

--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse } from './fetcher'
 
 export function getCart() {
-  return fetchWithResponse('cårt', {
+  return fetchWithResponse('cart', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -17,12 +17,12 @@ export function getOrders() {
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: 'PUT',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({paymentTypeId})
+    body: JSON.stringify({payment_type: paymentTypeId})
   })
 }

--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse, fetchWithoutResponse } from "./fetcher";
 
 export function getPaymentTypes() {
-  return fetchWithResponse('payment-types', {
+  return fetchWithResponse('paymenttypes', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -9,7 +9,7 @@ export function getPaymentTypes() {
 }
 
 export function addPaymentType(paymentType) {
-  return fetchWithResponse(`payment-types`, {
+  return fetchWithResponse(`paymenttypes`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -20,7 +20,7 @@ export function addPaymentType(paymentType) {
 }
 
 export function deletePaymentType(id) {
-  return fetchWithoutResponse(`payment-types/${id}`, {
+  return fetchWithoutResponse(`paymenttypes/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`

--- a/data/products.js
+++ b/data/products.js
@@ -31,11 +31,12 @@ export function getProductById(id) {
 }
 
 export function addProductToOrder(id) {
-  return fetchWithResponse(`products/${id}/add_to_order`, {
+  return fetchWithResponse(`profile/cart`, {
     method: 'POST',
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
+      Authorization: `Token ${localStorage.getItem('token')}`,
+      "Content-Type": "application/json",
+    }, body: JSON.stringify({ product_id: id })
   })
 }
 

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -32,8 +32,8 @@ export default function Cart() {
     })
   }, [])
 
-  const completeOrder = (paymentTypeId) => {
-    completeCurrentOrder(cart.id, paymentTypeId).then(() => router.push('/my-orders'))
+  const completeOrder = (cart, paymentTypeId) => {
+    completeCurrentOrder(cart, paymentTypeId).then(() => router.push('/my-orders'))
   }
 
   const removeProduct = (productId) => {
@@ -47,6 +47,7 @@ export default function Cart() {
         setShowModal={setShowCompleteForm}
         paymentTypes={paymentTypes}
         completeOrder={completeOrder}
+        cart={cart}
       />
       <CardLayout title="Your Current Order">
         <CartDetail cart={cart} removeProduct={removeProduct} />

--- a/pages/payments.js
+++ b/pages/payments.js
@@ -43,7 +43,7 @@ export default function Payments() {
             payments.map(payment => (
               <tr key={payment.id}>
                 <td>{payment.merchant_name}</td>
-                <td>{payment.obscured_num}</td>
+                <td>{payment.account_number}</td>
                 <td>
                   <span className="icon is-clickable" onClick={() => removePayment(payment.id)}>
                     <i className="fas fa-trash"></i>


### PR DESCRIPTION
Users can now navigate to their current orders in their cart and purchase them successfully. 

## Changes

- Passed cart as a prop. 
- ParseInt method used for converting our payment type to an integer from a string. 
- Fixed typos resulting in incorrect endpoints for PUT and GET requests. 


## Testing

Description of how to test code...

- [x] Login as Joe (username: joe, password: Admin8*)
- [x] Navigate to your cart, and click complete order. 
- [x] Select a payment type and complete.
- [x] You should be navigated to my orders view and all 4 orders should have payment types defined. If only three are defined, testing was NOT successful. 


## Related Issues

- Fixes #45 
