### PR TITLE
Heidel/stores/store list/client

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,23 +1,26 @@
-import Link from 'next/link'
+import Link from "next/link"
+import { ProductCard } from "../product/card.js"
 
-export function StoreCard({ store, width= "is-half" }) {
+export function StoreCard({ store, width = "is-half" }) {
   return (
     <div className={`column ${width}`}>
       <div className="card">
         <header className="card-header">
-          <p className="card-header-title">
-            {store.name}
-          </p>
+          <p className="card-header-title">{store.name}</p>
         </header>
         <div className="card-content">
           <p className="content">
             Owner: {store.seller.first_name} {store.seller.last_name}
           </p>
-          <div className="content">
-            {store.description}
-          </div>
+          <div className="content">{store.description}</div>
+          <div className="content">Products: {store.products.length}</div>
         </div>
         <footer className="card-footer">
+          <div className="">
+            {store.products.map((product) => {
+              return <ProductCard key={product.id} product={product} />
+            })}
+          </div>
           <Link href={`stores/${store.id}`}>
             <a className="card-footer-item">View Store</a>
           </Link>

--- a/pages/stores/index.js
+++ b/pages/stores/index.js
@@ -1,15 +1,14 @@
-import { useEffect, useState } from 'react'
-import Layout from '../../components/layout'
-import Navbar from '../../components/navbar'
-import { StoreCard } from '../../components/store/card'
-import { getStores } from '../../data/stores'
-
+import { useEffect, useState } from "react"
+import Layout from "../../components/layout"
+import Navbar from "../../components/navbar"
+import { StoreCard } from "../../components/store/card"
+import { getStores } from "../../data/stores"
 
 export default function Stores() {
   const [stores, setStores] = useState([])
 
   useEffect(() => {
-    getStores().then(data => {
+    getStores().then((data) => {
       if (data) {
         setStores(data)
       }
@@ -20,11 +19,12 @@ export default function Stores() {
     <>
       <h1 className="title">Stores</h1>
       <div className="columns is-multiline">
-      {
-        stores.map(store => (
-          <StoreCard store={store} key={store.id} />
-        ))
-      }
+        {stores.map(
+          (store) =>
+            store.products.length !== 0 && (
+              <StoreCard store={store} key={store.id} />
+            )
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
Added functionality to have Stores List and Store Info and Store Products list in Store View

TEST:
- [x] Make sure at least one user in your database has a store
- [x] Navigate to Stores View (`/stores`)
- [x] Confirm user's store is in View and had Owner name, Store description, number of products, and list of products

Ref: [#48](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/48)