### PR TITLE
Added dependency to useEffect that sets profile data on login

### DIFF
--- a/context/state.js
+++ b/context/state.js
@@ -14,29 +14,6 @@ export function AppWrapper({ children }) {
     setToken(localStorage.getItem("token"))
   }, [])
 
-  // useEffect(() => {
-  //   getUserStore().then((res) => {
-  //     setProfile({
-  //       ...profile,
-  //       store: res,
-  //     })
-  //   })
-  // }, [])
-
-  // useEffect(() => {
-  //   const authRoutes = ["/login", "/register"]
-  //   if (token) {
-  //     localStorage.setItem("token", token)
-  //     if (!authRoutes.includes(router.pathname)) {
-  //       getUserProfile().then((profileData) => {
-  //         if (profileData) {
-  //           setProfile(profileData)
-  //         }
-  //       })
-  //     }
-  //   }
-  // }, [token])
-
   useEffect(() => {
     const authRoutes = ["/login", "/register"]
     if (token) {
@@ -61,7 +38,7 @@ export function AppWrapper({ children }) {
           })
       }
     }
-  }, [token])
+  }, [token, router.pathname])
 
   return (
     <AppContext.Provider value={{ profile, token, setToken, setProfile }}>


### PR DESCRIPTION
This pull request completes ticket [#57](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/57). The profile state was not being set on login. I added a dependency in the use effect in AppWrapper to render when token is changed and when the router path changes to either` /login` or `/register`

## Changes

- Added router.pathname as a dependency to the useEffect for profile data in AppWrapper component
- I also removed unneeded/commented out Zombie code

## Testing

- [x]  Open the application in browser
- [x]  Login as a user.
- [x] In the dev tools under components in the AppWrapper state make sure the profile and store data is present
- [x] Logout to verify the state is removed 
- [x] log back in as another user to make sure the state is generated with the new user profile data.


## Related Issues

- Completes ticket [#57](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/57)