### PR TITLE
Fixed the like and unlike a product functionality to work with server response

### DIFF
--- a/components/product/detail.js
+++ b/components/product/detail.js
@@ -3,12 +3,14 @@ import { useState, useRef } from "react"
 import { addProductToOrder, recommendProduct } from "../../data/products"
 import Modal from "../modal"
 import { Input } from "../form-elements"
+import { useAppContext } from "../../context/state"
 
 export function Detail({ product, like, unlike }) {
   const router = useRouter()
   const usernameEl = useRef()
   const [showModal, setShowModal] = useState(false)
   const [showError, setShowError] = useState(false)
+  const { profile } = useAppContext();
 
 
   const addToCart = () => {
@@ -70,7 +72,7 @@ export function Detail({ product, like, unlike }) {
               </p>
               <p className="control">
                 {
-                  product.is_liked ?
+                  (product.likes?.some(like => like.customer === profile.id)) ?
                     <button className="button is-link is-outlined" onClick={unlike}>
                       <span className="icon is-small">
                         <i className="fas fa-heart-broken"></i>

--- a/data/products.js
+++ b/data/products.js
@@ -116,7 +116,7 @@ export function likeProduct(productId) {
 }
 
 export function unLikeProduct(productId) {
-  return fetchWithoutResponse(`products/${productId}/unlike`, {
+  return fetchWithoutResponse(`products/${productId}/like`, {
     method: "DELETE",
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -54,8 +54,8 @@ export default function Profile() {
       <CardLayout title="Products you've liked" width="is-full">
         <div className="columns is-multiline">
           {
-            profile.likes?.map(product => (
-              <ProductCard product={product} key={product.id} width="is-one-third" />
+            profile.likes?.map(likes => (
+              <ProductCard product={likes.product} key={likes.id} width="is-one-third" />
             ))
           }
         </div>


### PR DESCRIPTION
This pull request completes ticket [#29](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/29). Fixed the frontend to handle the server's response data for product likes.

## Changes

- Added profile data created in AppWrapper with the useAppContext function to add conditional to the like and unlike button in product details. It was set up to where the user could keep clicking like and not switching to unlike even though the user had already liked it.
- Fixed the delete fetch url endpoint to `like` instead of `unlike` since that is what the backend is expecting.
- Fixed the mapping of the liked products in the profile based on the server response.

## Testing

- [ ] Open the application in the browser.
- [ ] Log in as a user.
- [ ] Navigate to a product's details page by clicking on a product.
- [ ] Verify that if the user hasn't liked the product, a `Like Product` button is displayed.
- [ ] Click on the `Like Product` button and confirm that it changes to `Unlike Product`.
- [ ] Visit the user's profile to view all liked products and ensure that the newly liked product appears in the list.
- [ ] Revisit a product's details page by clicking on one of the products in the liked products list. 
- [ ] Click `Unlike Product` and verify that the button reverts to `Like Product`. 
- [ ] Confirm that the product is removed from the liked products list in the profile.


## Related Issues

- Completes ticket [#29](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/29)