### PR TITLE
Fix POST Error in New Product Form Without Image

### DIFF
--- a/pages/products/new.js
+++ b/pages/products/new.js
@@ -11,15 +11,19 @@ export default function NewProduct() {
   const saveProduct = () => {
     const { name, description, price, category, location, quantity, image } =
       formEl.current
-    const product = {
-      name: name.value,
-      description: description.value,
-      price: parseInt(price.value),
-      category_id: parseInt(category.value),
-      location: location.value,
-      quantity: parseInt(quantity.value),
-      image_path: image.value,
-    }
+      const product = {
+        name: name.value,
+        description: description.value,
+        price: parseInt(price.value),
+        category_id: parseInt(category.value),
+        location: location.value,
+        quantity: parseInt(quantity.value),
+      };
+    
+      if (image.value) {
+        product.image_path = image.value;
+      }
+    
     addProduct(product).then((res) => {
       router.push(`/products/${res.id}`)
     })


### PR DESCRIPTION
This PR addresses an issue in the new product form POST request where an error occurred when no image was added. Previously, the front end was sending the image_path in the request object even when no image was submitted. To resolve this, an if statement has been added to include the image_path property only when an image is actually inserted. This ensures that the image remains optional and prevents errors when no image is provided. Client side fix for ticket #62.

To test:

- [x] In the application, click on `add a new product` in the dropdown menu.
- [x] Fill out all the inputs in the form except for the image input
- [x] Click `save`
- [x] Verify that there are no errors, and you are navigated to the details view of the new product you created



